### PR TITLE
Ajout de modèles et services mock avec Provider

### DIFF
--- a/lib/core/service_providers.dart
+++ b/lib/core/service_providers.dart
@@ -1,0 +1,13 @@
+import 'package:provider/provider.dart';
+
+import '../services/mocks/auth_mock_service.dart';
+import '../services/mocks/profile_mock_service.dart';
+import '../services/mocks/match_mock_service.dart';
+import '../services/mocks/chat_mock_service.dart';
+
+List<Provider> appProviders = [
+  Provider<AuthMockService>(create: (_) => AuthMockService()),
+  Provider<ProfileMockService>(create: (_) => ProfileMockService()),
+  Provider<MatchMockService>(create: (_) => MatchMockService()),
+  Provider<ChatMockService>(create: (_) => ChatMockService()),
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'core/service_providers.dart';
+import 'ui/home_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    MultiProvider(
+      providers: appProviders,
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/models/match.dart
+++ b/lib/models/match.dart
@@ -1,0 +1,13 @@
+class Match {
+  final String id;
+  final String userAId;
+  final String userBId;
+  final DateTime matchedOn;
+
+  Match({
+    required this.id,
+    required this.userAId,
+    required this.userBId,
+    DateTime? matchedOn,
+  }) : matchedOn = matchedOn ?? DateTime.now();
+}

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,15 @@
+class Message {
+  final String id;
+  final String fromUserId;
+  final String toUserId;
+  final String content;
+  final DateTime timestamp;
+
+  Message({
+    required this.id,
+    required this.fromUserId,
+    required this.toUserId,
+    required this.content,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+}

--- a/lib/models/premium_status.dart
+++ b/lib/models/premium_status.dart
@@ -1,0 +1,1 @@
+enum PremiumStatus { free, premium }

--- a/lib/models/profile.dart
+++ b/lib/models/profile.dart
@@ -1,0 +1,11 @@
+class Profile {
+  final String userId;
+  String bio;
+  int age;
+
+  Profile({
+    required this.userId,
+    this.bio = '',
+    this.age = 18,
+  });
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,15 @@
+import 'premium_status.dart';
+
+class User {
+  final String id;
+  final String email;
+  final String name;
+  final PremiumStatus premiumStatus;
+
+  User({
+    required this.id,
+    required this.email,
+    required this.name,
+    this.premiumStatus = PremiumStatus.free,
+  });
+}

--- a/lib/services/mocks/auth_mock_service.dart
+++ b/lib/services/mocks/auth_mock_service.dart
@@ -1,0 +1,24 @@
+import '../../models/user.dart';
+
+class AuthMockService {
+  User? _currentUser;
+  final List<User> _users = [
+    User(id: '1', email: 'user1@example.com', name: 'User One'),
+    User(id: '2', email: 'user2@example.com', name: 'User Two'),
+  ];
+
+  User? get currentUser => _currentUser;
+
+  Future<User?> signIn(String email) async {
+    try {
+      _currentUser = _users.firstWhere((u) => u.email == email);
+    } catch (_) {
+      _currentUser = null;
+    }
+    return _currentUser;
+  }
+
+  void signOut() {
+    _currentUser = null;
+  }
+}

--- a/lib/services/mocks/chat_mock_service.dart
+++ b/lib/services/mocks/chat_mock_service.dart
@@ -1,0 +1,11 @@
+import '../../models/message.dart';
+
+class ChatMockService {
+  final Map<String, List<Message>> _messages = {};
+
+  List<Message> getMessages(String matchId) => _messages[matchId] ?? [];
+
+  void sendMessage(String matchId, Message message) {
+    _messages.putIfAbsent(matchId, () => []).add(message);
+  }
+}

--- a/lib/services/mocks/match_mock_service.dart
+++ b/lib/services/mocks/match_mock_service.dart
@@ -1,0 +1,15 @@
+import '../../models/match.dart';
+
+class MatchMockService {
+  final List<Match> _matches = [];
+
+  List<Match> matchesForUser(String userId) {
+    return _matches
+        .where((m) => m.userAId == userId || m.userBId == userId)
+        .toList();
+  }
+
+  void addMatch(Match match) {
+    _matches.add(match);
+  }
+}

--- a/lib/services/mocks/profile_mock_service.dart
+++ b/lib/services/mocks/profile_mock_service.dart
@@ -1,0 +1,11 @@
+import '../../models/profile.dart';
+
+class ProfileMockService {
+  final Map<String, Profile> _profiles = {};
+
+  Profile? getProfile(String userId) => _profiles[userId];
+
+  void setProfile(Profile profile) {
+    _profiles[profile.userId] = profile;
+  }
+}

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('You have pushed the button this many times:'),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Ajout des modèles User, Profile, Message, Match et PremiumStatus.
- Implémentation de services mock en mémoire pour l'authentification, les profils, les matchs et le chat.
- Injection globale de ces services via Provider et configuration du conteneur.

## Testing
- `flutter pub get` *(échec : commande introuvable)*
- `flutter test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75157b2c8320ba6a095222443b65