### PR TITLE
Add onboarding flow with signup validation and mock SMS verification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'pages/onboarding_page1.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,14 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Eon App',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const OnboardingPage1(),
     );
   }
 }

--- a/lib/pages/onboarding_page1.dart
+++ b/lib/pages/onboarding_page1.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'onboarding_page2.dart';
+
+class OnboardingPage1 extends StatelessWidget {
+  const OnboardingPage1({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Welcome to the App - Page 1'),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const OnboardingPage2()),
+                );
+              },
+              child: const Text('Next'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding_page2.dart
+++ b/lib/pages/onboarding_page2.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'onboarding_page3.dart';
+
+class OnboardingPage2 extends StatelessWidget {
+  const OnboardingPage2({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Discover Features - Page 2'),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const OnboardingPage3()),
+                );
+              },
+              child: const Text('Next'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding_page3.dart
+++ b/lib/pages/onboarding_page3.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'signup_page.dart';
+
+class OnboardingPage3 extends StatelessWidget {
+  const OnboardingPage3({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Get Started - Page 3'),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SignupPage()),
+                );
+              },
+              child: const Text('Get Started'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile_creation_page.dart
+++ b/lib/pages/profile_creation_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ProfileCreationPage extends StatelessWidget {
+  const ProfileCreationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Profile Creation Page'),
+      ),
+    );
+  }
+}

--- a/lib/pages/signup_page.dart
+++ b/lib/pages/signup_page.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import '../services/auth_mock_service.dart';
+import 'profile_creation_page.dart';
+
+class SignupPage extends StatefulWidget {
+  const SignupPage({super.key});
+
+  @override
+  State<SignupPage> createState() => _SignupPageState();
+}
+
+class _SignupPageState extends State<SignupPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _phoneController = TextEditingController();
+  final _ageController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _authService = AuthMockService();
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    _ageController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      await _authService.sendSms(_phoneController.text);
+      final codeController = TextEditingController();
+      final result = await showDialog<String>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Enter SMS Code'),
+          content: TextField(
+            controller: codeController,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(hintText: '123456'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, codeController.text),
+              child: const Text('Verify'),
+            ),
+          ],
+        ),
+      );
+      if (result != null) {
+        final verified = await _authService.verifySms(result);
+        if (verified) {
+          if (context.mounted) {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const ProfileCreationPage(),
+              ),
+            );
+          }
+        } else {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Invalid code')),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  String? _validatePhone(String? value) {
+    if (value == null || !value.startsWith('+261') || value.length != 13 || int.tryParse(value.substring(1)) == null) {
+      return 'Numéro invalide (+261XXXXXXXXX)';
+    }
+    return null;
+  }
+
+  String? _validateAge(String? value) {
+    final age = int.tryParse(value ?? '');
+    if (age == null || age < 18) {
+      return 'Vous devez avoir au moins 18 ans';
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    if (value == null || value.length < 6) {
+      return 'Mot de passe trop court';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Signup')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _phoneController,
+                decoration: const InputDecoration(labelText: 'Téléphone'),
+                keyboardType: TextInputType.phone,
+                validator: _validatePhone,
+              ),
+              TextFormField(
+                controller: _ageController,
+                decoration: const InputDecoration(labelText: 'Âge'),
+                keyboardType: TextInputType.number,
+                validator: _validateAge,
+              ),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Mot de passe'),
+                obscureText: true,
+                validator: _validatePassword,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('S'inscrire'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_mock_service.dart
+++ b/lib/services/auth_mock_service.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+class AuthMockService {
+  Future<void> sendSms(String phoneNumber) async {
+    // Simulate a network call delay
+    await Future.delayed(const Duration(seconds: 1));
+    // In a real service you would send an SMS here
+  }
+
+  Future<bool> verifySms(String code) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    // Accept a hardcoded verification code for simulation
+    return code == '123456';
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce three onboarding pages leading to signup
- Validate +261 phone, age, and password on signup
- Mock SMS sending/verification and redirect to profile creation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75160b1c8320872057c9ac226437