### PR TITLE
Add profile setup steps with mock service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'profile_flow.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,15 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Profile Setup',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const ProfileFlowPage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}

--- a/lib/profile_flow.dart
+++ b/lib/profile_flow.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'steps/photo_step.dart';
+import 'steps/personal_info_step.dart';
+import 'steps/culture_info_step.dart';
+import 'steps/preference_step.dart';
+
+class ProfileFlowPage extends StatefulWidget {
+  const ProfileFlowPage({super.key});
+
+  @override
+  State<ProfileFlowPage> createState() => _ProfileFlowPageState();
+}
+
+class _ProfileFlowPageState extends State<ProfileFlowPage> {
+  int _currentStep = 0;
+  final _photoKey = GlobalKey<PhotoStepState>();
+  final _personalKey = GlobalKey<PersonalInfoStepState>();
+  final _cultureKey = GlobalKey<CultureInfoStepState>();
+  final _preferenceKey = GlobalKey<PreferenceStepState>();
+
+  void _continue() {
+    bool success = false;
+    switch (_currentStep) {
+      case 0:
+        success = _photoKey.currentState?.save() ?? false;
+        break;
+      case 1:
+        success = _personalKey.currentState?.save() ?? false;
+        break;
+      case 2:
+        success = _cultureKey.currentState?.save() ?? false;
+        break;
+      case 3:
+        success = _preferenceKey.currentState?.save() ?? false;
+        break;
+    }
+    if (success && _currentStep < 3) {
+      setState(() {
+        _currentStep += 1;
+      });
+    }
+  }
+
+  void _cancel() {
+    if (_currentStep > 0) {
+      setState(() {
+        _currentStep -= 1;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stepper(
+      currentStep: _currentStep,
+      onStepContinue: _continue,
+      onStepCancel: _cancel,
+      steps: [
+        Step(title: const Text('Photo'), content: PhotoStep(key: _photoKey)),
+        Step(
+            title: const Text('Infos personnelles'),
+            content: PersonalInfoStep(key: _personalKey)),
+        Step(
+            title: const Text('Culture'),
+            content: CultureInfoStep(key: _cultureKey)),
+        Step(
+            title: const Text('Préférences'),
+            content: PreferenceStep(key: _preferenceKey)),
+      ],
+    );
+  }
+}
+

--- a/lib/profile_mock_service.dart
+++ b/lib/profile_mock_service.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class PersonalInfo {
+  final String bio;
+  final String profession;
+  final String education;
+  final String city;
+  final String region;
+
+  PersonalInfo({
+    required this.bio,
+    required this.profession,
+    required this.education,
+    required this.city,
+    required this.region,
+  });
+}
+
+class CultureInfo {
+  final String foko;
+  final String languages;
+  final String religion;
+  final String interests;
+
+  CultureInfo({
+    required this.foko,
+    required this.languages,
+    required this.religion,
+    required this.interests,
+  });
+}
+
+class PreferenceInfo {
+  final int minAge;
+  final int maxAge;
+  final double maxDistance;
+  final String languageFilter;
+
+  PreferenceInfo({
+    required this.minAge,
+    required this.maxAge,
+    required this.maxDistance,
+    required this.languageFilter,
+  });
+}
+
+class ProfileMockService {
+  ProfileMockService._internal();
+  static final ProfileMockService instance = ProfileMockService._internal();
+
+  String? photoPath;
+  PersonalInfo? personalInfo;
+  CultureInfo? cultureInfo;
+  PreferenceInfo? preferenceInfo;
+
+  void savePhoto(String path) {
+    photoPath = path;
+  }
+
+  void savePersonalInfo(PersonalInfo info) {
+    personalInfo = info;
+  }
+
+  void saveCultureInfo(CultureInfo info) {
+    cultureInfo = info;
+  }
+
+  void savePreferenceInfo(PreferenceInfo info) {
+    preferenceInfo = info;
+  }
+}
+

--- a/lib/steps/culture_info_step.dart
+++ b/lib/steps/culture_info_step.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../profile_mock_service.dart';
+
+class CultureInfoStep extends StatefulWidget {
+  const CultureInfoStep({super.key});
+
+  @override
+  CultureInfoStepState createState() => CultureInfoStepState();
+}
+
+class CultureInfoStepState extends State<CultureInfoStep> {
+  final _formKey = GlobalKey<FormState>();
+  final _fokoController = TextEditingController();
+  final _languagesController = TextEditingController();
+  final _religionController = TextEditingController();
+  final _interestsController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            controller: _fokoController,
+            decoration: const InputDecoration(labelText: 'Foko'),
+          ),
+          TextFormField(
+            controller: _languagesController,
+            decoration: const InputDecoration(labelText: 'Langues'),
+          ),
+          TextFormField(
+            controller: _religionController,
+            decoration: const InputDecoration(labelText: 'Religion'),
+          ),
+          TextFormField(
+            controller: _interestsController,
+            decoration: const InputDecoration(labelText: 'Centres d\'intérêt'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool save() {
+    if (_formKey.currentState!.validate()) {
+      ProfileMockService.instance.saveCultureInfo(
+        CultureInfo(
+          foko: _fokoController.text,
+          languages: _languagesController.text,
+          religion: _religionController.text,
+          interests: _interestsController.text,
+        ),
+      );
+      return true;
+    }
+    return false;
+  }
+}
+

--- a/lib/steps/personal_info_step.dart
+++ b/lib/steps/personal_info_step.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../profile_mock_service.dart';
+
+class PersonalInfoStep extends StatefulWidget {
+  const PersonalInfoStep({super.key});
+
+  @override
+  PersonalInfoStepState createState() => PersonalInfoStepState();
+}
+
+class PersonalInfoStepState extends State<PersonalInfoStep> {
+  final _formKey = GlobalKey<FormState>();
+  final _bioController = TextEditingController();
+  final _professionController = TextEditingController();
+  final _educationController = TextEditingController();
+  final _cityController = TextEditingController();
+  final _regionController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            controller: _bioController,
+            decoration: const InputDecoration(labelText: 'Bio'),
+          ),
+          TextFormField(
+            controller: _professionController,
+            decoration: const InputDecoration(labelText: 'Profession'),
+          ),
+          TextFormField(
+            controller: _educationController,
+            decoration: const InputDecoration(labelText: 'Éducation'),
+          ),
+          TextFormField(
+            controller: _cityController,
+            decoration: const InputDecoration(labelText: 'Ville'),
+          ),
+          TextFormField(
+            controller: _regionController,
+            decoration: const InputDecoration(labelText: 'Région'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool save() {
+    if (_formKey.currentState!.validate()) {
+      ProfileMockService.instance.savePersonalInfo(
+        PersonalInfo(
+          bio: _bioController.text,
+          profession: _professionController.text,
+          education: _educationController.text,
+          city: _cityController.text,
+          region: _regionController.text,
+        ),
+      );
+      return true;
+    }
+    return false;
+  }
+}
+

--- a/lib/steps/photo_step.dart
+++ b/lib/steps/photo_step.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import '../profile_mock_service.dart';
+
+class PhotoStep extends StatefulWidget {
+  const PhotoStep({super.key});
+
+  @override
+  PhotoStepState createState() => PhotoStepState();
+}
+
+class PhotoStepState extends State<PhotoStep> {
+  bool _selected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 150,
+          height: 150,
+          color: Colors.grey.shade300,
+          child: _selected
+              ? const Icon(Icons.check, size: 80)
+              : const Icon(Icons.person, size: 80),
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton(
+          onPressed: () {
+            setState(() {
+              _selected = true;
+            });
+          },
+          child: const Text('Select from gallery'),
+        ),
+      ],
+    );
+  }
+
+  bool save() {
+    if (_selected) {
+      ProfileMockService.instance.savePhoto('placeholder');
+      return true;
+    }
+    return false;
+  }
+}
+

--- a/lib/steps/preference_step.dart
+++ b/lib/steps/preference_step.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import '../profile_mock_service.dart';
+
+class PreferenceStep extends StatefulWidget {
+  const PreferenceStep({super.key});
+
+  @override
+  PreferenceStepState createState() => PreferenceStepState();
+}
+
+class PreferenceStepState extends State<PreferenceStep> {
+  RangeValues _ageRange = const RangeValues(18, 30);
+  double _distance = 10;
+  final _languageController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Tranche d\'âge'),
+        RangeSlider(
+          values: _ageRange,
+          min: 18,
+          max: 100,
+          divisions: 82,
+          labels: RangeLabels(
+            _ageRange.start.round().toString(),
+            _ageRange.end.round().toString(),
+          ),
+          onChanged: (values) {
+            setState(() {
+              _ageRange = values;
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        Text('Distance: ${_distance.round()} km'),
+        Slider(
+          value: _distance,
+          min: 1,
+          max: 100,
+          divisions: 99,
+          label: _distance.round().toString(),
+          onChanged: (v) {
+            setState(() {
+              _distance = v;
+            });
+          },
+        ),
+        TextField(
+          controller: _languageController,
+          decoration:
+              const InputDecoration(labelText: 'Filtres linguistiques'),
+        ),
+      ],
+    );
+  }
+
+  bool save() {
+    ProfileMockService.instance.savePreferenceInfo(
+      PreferenceInfo(
+        minAge: _ageRange.start.round(),
+        maxAge: _ageRange.end.round(),
+        maxDistance: _distance,
+        languageFilter: _languageController.text,
+      ),
+    );
+    return true;
+  }
+}
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,16 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:eon_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Profile flow has four steps', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(Stepper), findsOneWidget);
+    expect(find.text('Photo'), findsOneWidget);
+    expect(find.text('Infos personnelles'), findsOneWidget);
+    expect(find.text('Culture'), findsOneWidget);
+    expect(find.text('Préférences'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- Replace counter app with profile setup wizard
- Implement photo, personal, cultural and preference steps
- Store each step's data in a `ProfileMockService`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75183a1c8320a9ee0ab47203ab84