### PR TITLE
Add swipeable discovery page with mock matching

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'pages/discovery_page.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,116 +9,15 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Eon',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const DiscoveryPage(),
     );
   }
 }

--- a/lib/models/profile.dart
+++ b/lib/models/profile.dart
@@ -1,0 +1,7 @@
+class Profile {
+  final String id;
+  final String name;
+  final String imageUrl;
+
+  Profile({required this.id, required this.name, required this.imageUrl});
+}

--- a/lib/pages/discovery_page.dart
+++ b/lib/pages/discovery_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../models/profile.dart';
+import '../services/match_mock_service.dart';
+import '../services/conversation_mock_service.dart';
+import '../widgets/swipe_cards.dart';
+
+class DiscoveryPage extends StatefulWidget {
+  const DiscoveryPage({super.key});
+
+  @override
+  State<DiscoveryPage> createState() => _DiscoveryPageState();
+}
+
+class _DiscoveryPageState extends State<DiscoveryPage> {
+  final List<Profile> profiles = [
+    Profile(id: '1', name: 'Alice', imageUrl: ''),
+    Profile(id: '2', name: 'Bob', imageUrl: ''),
+    Profile(id: '3', name: 'Charlie', imageUrl: ''),
+  ];
+
+  Future<void> _onLike(Profile profile) async {
+    final match = await MatchMockService.tryMatch(profile);
+    if (match) {
+      ConversationMockService.createConversation(profile);
+      if (!mounted) return;
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => const _MatchDialog(),
+      );
+      await Future.delayed(const Duration(seconds: 1));
+      if (mounted) Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Discovery')),
+      body: SwipeCards(profiles: profiles, onLike: _onLike),
+    );
+  }
+}
+
+class _MatchDialog extends StatefulWidget {
+  const _MatchDialog();
+
+  @override
+  State<_MatchDialog> createState() => _MatchDialogState();
+}
+
+class _MatchDialogState extends State<_MatchDialog>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 500))
+          ..forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: CurvedAnimation(parent: _controller, curve: Curves.easeOut),
+      child: const AlertDialog(
+        content: Text('Mifankatiava'),
+      ),
+    );
+  }
+}

--- a/lib/services/conversation_mock_service.dart
+++ b/lib/services/conversation_mock_service.dart
@@ -1,0 +1,9 @@
+import '../models/profile.dart';
+
+class ConversationMockService {
+  static final List<Profile> conversations = [];
+
+  static void createConversation(Profile profile) {
+    conversations.add(profile);
+  }
+}

--- a/lib/services/match_mock_service.dart
+++ b/lib/services/match_mock_service.dart
@@ -1,0 +1,12 @@
+import '../models/profile.dart';
+
+class MatchMockService {
+  // Profiles that already liked the current user.
+  static final Set<String> _likedMe = {'2'}; // Only profile with id '2' liked us.
+
+  static Future<bool> tryMatch(Profile profile) async {
+    // Simulate network delay.
+    await Future.delayed(const Duration(milliseconds: 300));
+    return _likedMe.contains(profile.id);
+  }
+}

--- a/lib/widgets/swipe_cards.dart
+++ b/lib/widgets/swipe_cards.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../models/profile.dart';
+
+class SwipeCards extends StatefulWidget {
+  final List<Profile> profiles;
+  final void Function(Profile) onLike;
+
+  const SwipeCards({super.key, required this.profiles, required this.onLike});
+
+  @override
+  State<SwipeCards> createState() => _SwipeCardsState();
+}
+
+class _SwipeCardsState extends State<SwipeCards> {
+  int index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (index >= widget.profiles.length) {
+      return const Center(child: Text('No more profiles'));
+    }
+
+    final profile = widget.profiles[index];
+    return Center(
+      child: Draggable(
+        feedback: _buildCard(profile),
+        childWhenDragging: const SizedBox.shrink(),
+        onDragEnd: (details) {
+          if (details.offset.dx > 100) {
+            widget.onLike(profile);
+          }
+          setState(() {
+            index++;
+          });
+        },
+        child: _buildCard(profile),
+      ),
+    );
+  }
+
+  Widget _buildCard(Profile profile) {
+    return Card(
+      elevation: 4,
+      child: SizedBox(
+        width: 300,
+        height: 400,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.person, size: 100),
+            const SizedBox(height: 16),
+            Text(profile.name, style: const TextStyle(fontSize: 24)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,9 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:eon_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Discovery page shows first profile', (tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add mock `Profile` model and services for matching and conversations
- implement swipeable `DiscoveryPage` using custom draggable cards
- show “Mifankatiava” animation and create conversation on mutual like

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac751982f08320ab6fd46dee6a2acd