### PR TITLE
Add mock chat with conversation list and message status updates

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'pages/conversation_list_page.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,116 +9,14 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Eon Chat',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const ConversationListPage(),
     );
   }
 }

--- a/lib/models/match.dart
+++ b/lib/models/match.dart
@@ -1,0 +1,5 @@
+class Match {
+  final String id;
+  final String name;
+  Match({required this.id, required this.name});
+}

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,15 @@
+enum MessageStatus { sending, sent, delivered, read }
+
+class Message {
+  final String id;
+  final String text;
+  final bool fromMe;
+  MessageStatus status;
+
+  Message({
+    required this.id,
+    required this.text,
+    required this.fromMe,
+    this.status = MessageStatus.sending,
+  });
+}

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../models/message.dart';
+import '../models/match.dart';
+import '../services/chat_mock_service.dart';
+
+class ChatPage extends StatefulWidget {
+  final Match match;
+  const ChatPage({super.key, required this.match});
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final ChatMockService _service = ChatMockService();
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.match.name)),
+      body: Column(
+        children: [
+          Expanded(
+            child: StreamBuilder<List<Message>>(
+              stream: _service.messagesStream(widget.match.id),
+              builder: (context, snapshot) {
+                final messages = snapshot.data ?? [];
+                WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+                return ListView.builder(
+                  controller: _scrollController,
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    final msg = messages[index];
+                    return _buildMessage(msg);
+                  },
+                );
+              },
+            ),
+          ),
+          _buildInput(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessage(Message msg) {
+    final alignment = msg.fromMe ? Alignment.centerRight : Alignment.centerLeft;
+    final color = msg.fromMe ? Colors.blue[200] : Colors.grey[300];
+    final statusText = msg.fromMe ? _statusText(msg.status) : '';
+    return Container(
+      alignment: alignment,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Column(
+        crossAxisAlignment:
+            msg.fromMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(msg.text),
+          ),
+          if (statusText.isNotEmpty)
+            Text(statusText, style: const TextStyle(fontSize: 10)),
+        ],
+      ),
+    );
+  }
+
+  String _statusText(MessageStatus status) {
+    switch (status) {
+      case MessageStatus.sending:
+        return 'sending';
+      case MessageStatus.sent:
+        return 'sent';
+      case MessageStatus.delivered:
+        return 'delivered';
+      case MessageStatus.read:
+        return 'read';
+    }
+  }
+
+  Widget _buildInput() {
+    return SafeArea(
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _textController,
+              decoration: const InputDecoration(
+                hintText: 'Message',
+                contentPadding: EdgeInsets.all(8),
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.send),
+            onPressed: _handleSend,
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _handleSend() {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
+    final message = Message(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      text: text,
+      fromMe: true,
+    );
+    _service.send(widget.match.id, message);
+    _textController.clear();
+    _scrollToBottom();
+  }
+
+  void _scrollToBottom() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/pages/conversation_list_page.dart
+++ b/lib/pages/conversation_list_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../models/match.dart';
+import '../services/chat_mock_service.dart';
+import 'chat_page.dart';
+
+class ConversationListPage extends StatelessWidget {
+  const ConversationListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final matches = ChatMockService().getMatches();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Matches')),
+      body: ListView.builder(
+        itemCount: matches.length,
+        itemBuilder: (context, index) {
+          final Match match = matches[index];
+          return ListTile(
+            title: Text(match.name),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => ChatPage(match: match)),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/chat_mock_service.dart
+++ b/lib/services/chat_mock_service.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import '../models/message.dart';
+import '../models/match.dart';
+
+class ChatMockService {
+  static final ChatMockService _instance = ChatMockService._internal();
+  factory ChatMockService() => _instance;
+  ChatMockService._internal();
+
+  final List<Match> _matches = [
+    Match(id: '1', name: 'Alice'),
+    Match(id: '2', name: 'Bob'),
+    Match(id: '3', name: 'Charlie'),
+  ];
+
+  final Map<String, List<Message>> _messages = {};
+  final Map<String, StreamController<List<Message>>> _controllers = {};
+
+  List<Match> getMatches() => _matches;
+
+  Stream<List<Message>> messagesStream(String conversationId) {
+    _controllers.putIfAbsent(
+        conversationId, () => StreamController<List<Message>>.broadcast());
+    _messages.putIfAbsent(conversationId, () => []);
+    // Emit current messages
+    _controllers[conversationId]!.add(List.from(_messages[conversationId]!));
+    return _controllers[conversationId]!.stream;
+  }
+
+  void send(String conversationId, Message message) {
+    final list = _messages.putIfAbsent(conversationId, () => []);
+    list.add(message);
+    _controllers[conversationId]?.add(List.from(list));
+
+    // simulate status updates
+    Future.delayed(const Duration(milliseconds: 300), () {
+      message.status = MessageStatus.sent;
+      _controllers[conversationId]?.add(List.from(list));
+    });
+    Future.delayed(const Duration(milliseconds: 600), () {
+      message.status = MessageStatus.delivered;
+      _controllers[conversationId]?.add(List.from(list));
+    });
+    Future.delayed(const Duration(milliseconds: 900), () {
+      message.status = MessageStatus.read;
+      _controllers[conversationId]?.add(List.from(list));
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add conversation list and chat pages
- mock service sends messages and updates local status
- auto-scroll to latest message after sending or receiving

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751a85cc8320b776433f734effe4