### PR TITLE
Add mock translation and ChatPage language detection

### DIFF
--- a/lib/chat_page.dart
+++ b/lib/chat_page.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'translation_mock_service.dart';
+
+class Message {
+  Message({required this.text, required this.lang, this.translated});
+  final String text;
+  final String lang;
+  String? translated;
+}
+
+class ChatPage extends StatefulWidget {
+  const ChatPage({super.key, this.premium = false});
+  final bool premium;
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final List<Message> _messages = [];
+  final TextEditingController _controller = TextEditingController();
+
+  String _detectLanguage(String text) {
+    final lower = text.toLowerCase();
+    if (lower.contains('fihavanana') || lower.contains('vintana') || lower.contains('ny') || lower.contains('ao')) {
+      return 'mg';
+    }
+    return 'en';
+  }
+
+  void _sendMessage() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    final lang = _detectLanguage(text);
+    final msg = Message(text: text, lang: lang);
+    if (widget.premium) {
+      msg.translated = TranslationMockService.translate(text, lang, lang == 'en' ? 'mg' : 'en');
+    }
+    setState(() {
+      _messages.add(msg);
+    });
+    _controller.clear();
+  }
+
+  void _translate(Message msg) {
+    msg.translated = TranslationMockService.translate(msg.text, msg.lang, msg.lang == 'en' ? 'mg' : 'en');
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chat')),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                return ListTile(
+                  title: Text(msg.text),
+                  subtitle: msg.translated != null ? Text(msg.translated!) : null,
+                  trailing: msg.translated == null && !widget.premium
+                      ? TextButton(
+                          onPressed: () => _translate(msg),
+                          child: const Text('Translate'),
+                        )
+                      : null,
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(hintText: 'Enter message'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _sendMessage,
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'chat_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,14 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const ChatPage(),
     );
   }
 }

--- a/lib/translation_mock_service.dart
+++ b/lib/translation_mock_service.dart
@@ -1,0 +1,38 @@
+import 'dart:core';
+
+class TranslationMockService {
+  static const _culturalTerms = {
+    'fihavanana',
+    'vintana',
+  };
+
+  static final Map<String, String> _enToMg = {
+    'hello': 'salama',
+    'world': 'tany',
+  };
+
+  static final Map<String, String> _mgToEn = {
+    'salama': 'hello',
+    'tany': 'world',
+  };
+
+  static String translate(String text, String from, String to) {
+    final lower = text.split(' ');
+    final buffer = <String>[];
+    for (final word in lower) {
+      final key = word.toLowerCase();
+      if (_culturalTerms.contains(key)) {
+        buffer.add(word);
+        continue;
+      }
+      if (from == 'en' && to == 'mg') {
+        buffer.add(_enToMg[key] ?? word);
+      } else if (from == 'mg' && to == 'en') {
+        buffer.add(_mgToEn[key] ?? word);
+      } else {
+        buffer.add(word);
+      }
+    }
+    return buffer.join(' ');
+  }
+}

--- a/test/translation_mock_service_test.dart
+++ b/test/translation_mock_service_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eon_app/translation_mock_service.dart';
+
+void main() {
+  test('preserves cultural terms', () {
+    final result = TranslationMockService.translate('Fihavanana sy Vintana', 'mg', 'en');
+    expect(result, 'Fihavanana sy Vintana');
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,26 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:eon_app/main.dart';
+import 'package:eon_app/chat_page.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+  testWidgets('manual translation displayed on request', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ChatPage()));
+    await tester.enterText(find.byType(TextField), 'Hello');
+    await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.text('salama'), findsNothing);
+    await tester.tap(find.text('Translate'));
+    await tester.pump();
+    expect(find.text('salama'), findsOneWidget);
+  });
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('premium translates immediately', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ChatPage(premium: true)));
+    await tester.enterText(find.byType(TextField), 'Hello');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.text('salama'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Add ChatPage with simple language detection and translation display
- Provide TranslationMockService preserving cultural terms like Fihavanana and Vintana
- Add tests for translation and ChatPage manual/premium modes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751b9b7c8320bf7770c5184ac4fe