### PR TITLE
Implement premium upgrade flow with swipe limits

### DIFF
--- a/lib/discovery_page.dart
+++ b/lib/discovery_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'premium_upsell_page.dart';
+import 'services/premium_mock_service.dart';
+
+class DiscoveryPage extends StatefulWidget {
+  const DiscoveryPage({Key? key}) : super(key: key);
+
+  @override
+  State<DiscoveryPage> createState() => _DiscoveryPageState();
+}
+
+class _DiscoveryPageState extends State<DiscoveryPage> {
+  static const int freeSwipes = 20;
+  static const int freeSuperLikes = 1;
+
+  int remainingSwipes = freeSwipes;
+  int remainingSuperLikes = freeSuperLikes;
+
+  void _performSwipe() async {
+    if (PremiumMockService.isPremium) return;
+    if (remainingSwipes > 0) {
+      setState(() => remainingSwipes--);
+      if (remainingSwipes == 0) {
+        await _showUpsell();
+      }
+    } else {
+      await _showUpsell();
+    }
+  }
+
+  void _performSuperLike() async {
+    if (PremiumMockService.isPremium) return;
+    if (remainingSuperLikes > 0) {
+      setState(() => remainingSuperLikes--);
+      if (remainingSuperLikes == 0) {
+        await _showUpsell();
+      }
+    } else {
+      await _showUpsell();
+    }
+  }
+
+  Future<bool> _showUpsell() async {
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(builder: (_) => const PremiumUpsellPage()),
+    );
+    setState(() {});
+    return result ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final premium = PremiumMockService.isPremium;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Discovery')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (!premium) Text('Swipes left: $remainingSwipes'),
+            if (!premium) Text('Super Likes left: $remainingSuperLikes'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _performSwipe,
+              child: Text(premium ? 'Swipe (unlimited)' : 'Swipe'),
+            ),
+            ElevatedButton(
+              onPressed: _performSuperLike,
+              child: Text(premium ? 'Super Like (unlimited)' : 'Super Like'),
+            ),
+            const SizedBox(height: 40),
+            ListTile(
+              title: const Text('Auto translation'),
+              trailing: premium
+                  ? const Icon(Icons.check, color: Colors.green)
+                  : const Icon(Icons.lock),
+            ),
+            ListTile(
+              title: const Text('Advanced filters'),
+              trailing: premium
+                  ? const Icon(Icons.check, color: Colors.green)
+                  : const Icon(Icons.lock),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'discovery_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,14 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Eon Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const DiscoveryPage(),
     );
   }
 }

--- a/lib/premium_upsell_page.dart
+++ b/lib/premium_upsell_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'services/premium_mock_service.dart';
+
+class PremiumUpsellPage extends StatelessWidget {
+  const PremiumUpsellPage({Key? key}) : super(key: key);
+
+  void _upgrade(BuildContext context) {
+    PremiumMockService.upgrade();
+    Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Go Premium')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => _upgrade(context),
+          child: const Text('Upgrade (Mock)'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/premium_mock_service.dart
+++ b/lib/services/premium_mock_service.dart
@@ -1,0 +1,9 @@
+class PremiumMockService {
+  static bool _isPremium = false;
+
+  static bool get isPremium => _isPremium;
+
+  static void upgrade() {
+    _isPremium = true;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `PremiumMockService` and `PremiumUpsellPage` to simulate premium upgrade
- Track free swipe and super like quotas in `DiscoveryPage` and navigate to upsell when exhausted
- Update app entry to launch `DiscoveryPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751c80ec8320837060f921f86d0a