### PR TITLE
feat: add report and block menu options

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'services/moderation_mock_service.dart';
+import 'services/block_mock_service.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,45 +9,16 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    return const MaterialApp(
+      home: MyHomePage(title: 'Chat'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
 
   final String title;
 
@@ -54,69 +27,118 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+  final String _userId = 'user123';
+  final TextEditingController _controller = TextEditingController();
+  final List<String> _messages = [];
 
-  void _incrementCounter() {
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _sendMessage() {
+    if (_controller.text.isEmpty) return;
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _messages.add(_controller.text);
+      _controller.clear();
     });
+  }
+
+  Future<void> _handleMenu(String value) async {
+    if (value == 'report') {
+      final reason = await showDialog<String>(
+        context: context,
+        builder: (context) {
+          final TextEditingController reasonController =
+              TextEditingController();
+          return AlertDialog(
+            title: const Text('Signaler'),
+            content: TextField(
+              controller: reasonController,
+              decoration: const InputDecoration(
+                hintText: 'Raison',
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Annuler'),
+              ),
+              TextButton(
+                onPressed: () =>
+                    Navigator.of(context).pop(reasonController.text),
+                child: const Text('Envoyer'),
+              ),
+            ],
+          );
+        },
+      );
+      if (reason != null && reason.isNotEmpty) {
+        ModerationMockService.report(_userId, reason);
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Utilisateur signalé')),
+        );
+      }
+    } else if (value == 'block') {
+      BlockMockService.block(_userId);
+      setState(() {});
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    final blocked = BlockMockService.isBlocked(_userId);
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: _handleMenu,
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: 'report', child: Text('Signaler')),
+              PopupMenuItem(value: 'block', child: Text('Bloquer')),
+            ],
+          ),
+        ],
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView(
+              children: _messages
+                  .map((m) => ListTile(title: Text(m)))
+                  .toList(),
             ),
-          ],
-        ),
+          ),
+          if (blocked)
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Text('Conversation en lecture seule'),
+            )
+          else
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      decoration: const InputDecoration(
+                        hintText: 'Votre message',
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.send),
+                    onPressed: _sendMessage,
+                  ),
+                ],
+              ),
+            ),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/services/block_mock_service.dart
+++ b/lib/services/block_mock_service.dart
@@ -1,0 +1,10 @@
+class BlockMockService {
+  static final Set<String> _blocked = <String>{};
+
+  static void block(String userId) {
+    _blocked.add(userId);
+    // In a real app, this would remove the user from discovery and conversations lists.
+  }
+
+  static bool isBlocked(String userId) => _blocked.contains(userId);
+}

--- a/lib/services/moderation_mock_service.dart
+++ b/lib/services/moderation_mock_service.dart
@@ -1,0 +1,16 @@
+class ModerationMockService {
+  static final List<_Report> _reports = [];
+
+  static void report(String userId, String reason) {
+    _reports.add(_Report(userId, reason));
+  }
+
+  static List<_Report> get reports => List.unmodifiable(_reports);
+}
+
+class _Report {
+  final String userId;
+  final String reason;
+
+  _Report(this.userId, this.reason);
+}


### PR DESCRIPTION
## Summary
- add simple moderation and block mock services
- expose Signaler and Bloquer options in chat menu
- show conversation as read-only for blocked users

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter format lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751d8a208320b0d8b8cc50a37e4e