### PR TITLE
feat: add admin mock service

### DIFF
--- a/lib/services/admin_mock_service.dart
+++ b/lib/services/admin_mock_service.dart
@@ -1,0 +1,51 @@
+/// A simple mock service providing administrative data.
+///
+/// The service collects static reports and basic usage statistics. It is
+/// designed to be easily replaced by a real implementation connected to
+/// back-end services or analytics providers.
+class AdminMockService {
+  /// Internal list of textual reports.
+  final List<String> _reports = <String>[
+    'Daily system health check passed',
+    'User signups increased by 20% this week',
+    'No critical alerts in the last 24 hours',
+  ];
+
+  /// Internal list of usage statistics.
+  /// Each entry is a simple map containing a [metric] name and a [value].
+  final List<Map<String, Object>> _usageStats = <Map<String, Object>>[
+    <String, Object>{'metric': 'activeUsers', 'value': 123},
+    <String, Object>{'metric': 'sessions', 'value': 456},
+    <String, Object>{'metric': 'errors', 'value': 0},
+  ];
+
+  /// Returns a static list of reports.
+  ///
+  /// Future versions may fetch data from a reporting backend or stream
+  /// real-time updates.
+  List<String> getReports() => List<String>.unmodifiable(_reports);
+
+  /// Returns a static list of basic usage statistics.
+  ///
+  /// In a real implementation this could interface with analytics services
+  /// or provide observable streams for dashboard widgets.
+  List<Map<String, Object>> getUsageStats() =>
+      List<Map<String, Object>>.unmodifiable(_usageStats);
+
+  // ---------------------------------------------------------------------------
+  // Extension points
+  // ---------------------------------------------------------------------------
+  // The methods below allow the mock service to be extended or replaced when
+  // integrating with a full-featured admin dashboard. They can be removed or
+  // expanded upon once real data sources are available.
+
+  /// Adds a new report to the collection.
+  void addReport(String report) {
+    _reports.add(report);
+  }
+
+  /// Adds a new usage statistic entry.
+  void addUsageStat(String metric, Object value) {
+    _usageStats.add(<String, Object>{'metric': metric, 'value': value});
+  }
+}


### PR DESCRIPTION
## Summary
- add AdminMockService for mock reports and usage stats
- expose getReports and getUsageStats methods with static data
- include extension hooks for future dashboard integration

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751e9aa48320a11418696713be89