### PR TITLE
refactor: unify message model

### DIFF
--- a/lib/chat_page.dart
+++ b/lib/chat_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'translation_mock_service.dart';
 
-class Message {
-  Message({required this.text, required this.lang, this.translated});
+class TranslationMessage {
+  TranslationMessage({required this.text, required this.lang, this.translated});
   final String text;
   final String lang;
   String? translated;
@@ -17,7 +17,7 @@ class ChatPage extends StatefulWidget {
 }
 
 class _ChatPageState extends State<ChatPage> {
-  final List<Message> _messages = [];
+  final List<TranslationMessage> _messages = [];
   final TextEditingController _controller = TextEditingController();
 
   String _detectLanguage(String text) {
@@ -32,7 +32,7 @@ class _ChatPageState extends State<ChatPage> {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     final lang = _detectLanguage(text);
-    final msg = Message(text: text, lang: lang);
+    final msg = TranslationMessage(text: text, lang: lang);
     if (widget.premium) {
       msg.translated = TranslationMockService.translate(text, lang, lang == 'en' ? 'mg' : 'en');
     }
@@ -42,7 +42,7 @@ class _ChatPageState extends State<ChatPage> {
     _controller.clear();
   }
 
-  void _translate(Message msg) {
+  void _translate(TranslationMessage msg) {
     msg.translated = TranslationMockService.translate(msg.text, msg.lang, msg.lang == 'en' ? 'mg' : 'en');
     setState(() {});
   }

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,10 +1,10 @@
-
 enum MessageStatus { sending, sent, delivered, read }
 
 class Message {
   final String id;
   final String text;
   final bool fromMe;
+  final DateTime timestamp;
   MessageStatus status;
 
   Message({
@@ -12,21 +12,6 @@ class Message {
     required this.text,
     required this.fromMe,
     this.status = MessageStatus.sending,
-  });
-
-class Message {
-  final String id;
-  final String fromUserId;
-  final String toUserId;
-  final String content;
-  final DateTime timestamp;
-
-  Message({
-    required this.id,
-    required this.fromUserId,
-    required this.toUserId,
-    required this.content,
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
-
 }


### PR DESCRIPTION
## Summary
- consolidate Message model with id, text, fromMe, status, and timestamp
- rename translation chat's Message class to avoid duplication

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc1345b48832083aa2b605b0055d9