### PR TITLE
Refactor Profile model to single constructor

### DIFF
--- a/lib/models/profile.dart
+++ b/lib/models/profile.dart
@@ -1,19 +1,18 @@
 class Profile {
-
   final String id;
   final String name;
   final String imageUrl;
-
-  Profile({required this.id, required this.name, required this.imageUrl});
-
   final String userId;
   String bio;
   int age;
 
   Profile({
+    required this.id,
+    required this.name,
+    required this.imageUrl,
     required this.userId,
     this.bio = '',
     this.age = 18,
   });
-
 }
+

--- a/lib/pages/discovery_page.dart
+++ b/lib/pages/discovery_page.dart
@@ -14,9 +14,9 @@ class DiscoveryPage extends StatefulWidget {
 
 class _DiscoveryPageState extends State<DiscoveryPage> {
   final List<Profile> profiles = [
-    Profile(id: '1', name: 'Alice', imageUrl: ''),
-    Profile(id: '2', name: 'Bob', imageUrl: ''),
-    Profile(id: '3', name: 'Charlie', imageUrl: ''),
+    Profile(id: '1', name: 'Alice', imageUrl: '', userId: '1'),
+    Profile(id: '2', name: 'Bob', imageUrl: '', userId: '2'),
+    Profile(id: '3', name: 'Charlie', imageUrl: '', userId: '3'),
   ];
 
   Future<void> _onLike(Profile profile) async {


### PR DESCRIPTION
## Summary
- merge Profile constructors into one with defaults for `bio` and `age`
- require `userId` when creating a profile and update discovery page

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc1356e5c832092813de519f87eb7